### PR TITLE
Bumped the version of babel to the latest in the 5.x range

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/noyesa/broccoli-global-exporter#readme",
   "dependencies": {
-    "babel": "^5.5.8",
+    "babel": "^5.8.34",
     "broccoli-plugin": "^1.2.1",
     "lodash.assign": "^3.2.0",
     "lodash.defaults": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-global-exporter",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Exports global variables using ES6 module syntax.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Accidentally started this with an older version of the babel 5.x range due to the version available in our internal npm registry being out of date. Bumped to the latest available 5.x version.
