### PR TITLE
Add CJS exporter

### DIFF
--- a/specs/global-exporter.js
+++ b/specs/global-exporter.js
@@ -1,33 +1,34 @@
 var expect = require('chai').expect,
-    GlobalExporter = require('../dist/global-exporter');
+    CjsGlobalExporter = require('../dist/global-exporter').CjsGlobalExporter,
+    Es6GlobalExporter = require('../dist/global-exporter').Es6GlobalExporter;
 
-describe('GlobalExporter', function() {
+describe('Es6GlobalExporter', function() {
   it('is a thing', function() {
-    expect(GlobalExporter).to.be.a('function');
+    expect(Es6GlobalExporter).to.be.a('function');
   });
 
   describe('construction', function() {
     it('throws an exception when instantiated without arguments', function() {
       expect(function() {
-        new GlobalExporter();
+        new Es6GlobalExporter();
       }).to.throw(Error);
     });
 
     it('instantiates without error when defaultExport is specified', function() {
       expect(function() {
-        new GlobalExporter('Foo');
+        new Es6GlobalExporter('Foo');
       }).to.not.throw(Error);
     });
 
     it('sets the property defaultExports with the first argument', function() {
-      var exporter = new GlobalExporter('Foo');
+      var exporter = new Es6GlobalExporter('Foo');
       expect(exporter)
         .to.have.property('defaultExport')
         .that.equals('Foo');
     });
 
     it('sets exports to an empty array when not provided', function() {
-      var exporter = new GlobalExporter('Foo');
+      var exporter = new Es6GlobalExporter('Foo');
       expect(exporter)
         .to.have.property('exports')
         .that.is.an('array')
@@ -35,7 +36,7 @@ describe('GlobalExporter', function() {
     });
 
     it('sets exports to the passed exports when provided', function() {
-      var exporter = new GlobalExporter('Foo', ['bar', 'baz']);
+      var exporter = new Es6GlobalExporter('Foo', ['bar', 'baz']);
       expect(exporter)
         .to.have.property('exports')
         .that.is.an('array')
@@ -43,7 +44,7 @@ describe('GlobalExporter', function() {
     });
 
     it('can be constructed without passing a default export', function() {
-      var exporter = new GlobalExporter(undefined, ['foo', 'bar']);
+      var exporter = new Es6GlobalExporter(undefined, ['foo', 'bar']);
       expect(exporter)
         .to.have.property('defaultExport')
         .that.is.undefined;
@@ -57,7 +58,7 @@ describe('GlobalExporter', function() {
 
   describe('processSourceCode', function() {
     it('is a method', function() {
-      var exporter = new GlobalExporter('Foo');
+      var exporter = new Es6GlobalExporter('Foo');
       expect(exporter)
         .to.have.property('processSourceCode')
         .that.is.a('function');
@@ -65,7 +66,7 @@ describe('GlobalExporter', function() {
 
     it('adds default export statements to the source code', function() {
       var sourceCode = 'var foo = 1;',
-          exporter = new GlobalExporter('foo');
+          exporter = new Es6GlobalExporter('foo');
 
       expect(sourceCode).to.not.contain('export default foo;');
       sourceCode = exporter.processSourceCode(sourceCode);
@@ -74,11 +75,88 @@ describe('GlobalExporter', function() {
 
     it('adds named exports to the source code', function() {
       var sourceCode = 'var foo = 1;',
-          exporter = new GlobalExporter(undefined, ['foo']);
+          exporter = new Es6GlobalExporter(undefined, ['foo']);
 
       expect(sourceCode).to.not.contain('export foo;');
       sourceCode = exporter.processSourceCode(sourceCode);
       expect(sourceCode).to.contain('export foo;');
+    });
+  });
+});
+
+describe('CjsGlobalExporter', function() {
+  it('is a thing', function() {
+    expect(CjsGlobalExporter).to.be.a('function');
+  });
+
+  describe('construction', function() {
+    it('throws an exception when instantiated without arguments', function() {
+      expect(function() {
+        new CjsGlobalExporter();
+      }).to.throw(Error);
+    });
+
+    it('instantiates without error when defaultExport is specified', function() {
+      expect(function() {
+        new CjsGlobalExporter('Foo');
+      }).to.not.throw(Error);
+    });
+
+    it('sets the property defaultExports with the first argument', function() {
+      var exporter = new CjsGlobalExporter('Foo');
+      expect(exporter)
+        .to.have.property('defaultExport')
+        .that.equals('Foo');
+    });
+
+    it('sets exports to an empty array when not provided', function() {
+      var exporter = new CjsGlobalExporter('Foo');
+      expect(exporter)
+        .to.have.property('exports')
+        .that.is.an('array')
+        .that.is.empty;
+    });
+
+    it('sets exports to the passed exports when provided', function() {
+      var exporter = new CjsGlobalExporter('Foo', ['bar', 'baz']);
+      expect(exporter)
+        .to.have.property('exports')
+        .that.is.an('array')
+        .that.deep.equals(['bar', 'baz']);
+    });
+
+    it('can be constructed without passing a default export', function() {
+      var exporter = new CjsGlobalExporter(undefined, ['foo', 'bar']);
+      expect(exporter)
+        .to.have.property('defaultExport')
+        .that.is.undefined;
+
+      expect(exporter)
+        .to.have.property('exports')
+        .that.is.an('array')
+        .that.deep.equals(['foo', 'bar']);
+    });
+  });
+
+  describe('processSourceCode', function() {
+    it('adds default export statements to the source code', function() {
+      var sourceCode = 'var foo = 1;',
+          exporter = new CjsGlobalExporter('foo');
+
+      expect(sourceCode).to.not.contain('exports[\'default\'] = foo;');
+      expect(sourceCode).to.not.contain('__esModule');
+      sourceCode = exporter.processSourceCode(sourceCode);
+      expect(sourceCode).to.contain('exports[\'default\'] = foo;');
+      expect(sourceCode).to.contain('__esModule');
+    });
+
+    it('adds named exports to the source code', function() {
+      var sourceCode = 'var foo = 1;',
+          exporter = new CjsGlobalExporter(undefined, ['foo']);
+
+      expect(sourceCode).to.not.contain('exports.foo = foo;');
+      sourceCode = exporter.processSourceCode(sourceCode);
+      expect(sourceCode).to.contain('exports.foo = foo;');
     });
   });
 });

--- a/specs/global-exporter.js
+++ b/specs/global-exporter.js
@@ -19,11 +19,6 @@ describe('GlobalExporter', function() {
       }).to.not.throw(Error);
     });
 
-    it('can be instantiated without using the new keyword', function() {
-      var exporter = GlobalExporter('Foo');
-      expect(exporter).to.be.an.instanceof(GlobalExporter);
-    });
-
     it('sets the property defaultExports with the first argument', function() {
       var exporter = new GlobalExporter('Foo');
       expect(exporter)

--- a/src/global-exporter.js
+++ b/src/global-exporter.js
@@ -18,18 +18,14 @@ export class BaseGlobalExporter {
    * @returns {string[]} Array of named export strings
    * @abstract
    */
-  getNamedExports() {
-    throw new Error('not implemented');
-  }
+  getNamedExports() {}
 
   /**
    * Returns default export string.
    * @returns {string} Default export string
    * @abstract
    */
-  getDefaultExport() {
-    throw new Error('not implemented');
-  }
+  getDefaultExport() {}
 
   /**
    * Gets array of all the export statements.
@@ -96,7 +92,7 @@ export class CjsGlobalExporter extends BaseGlobalExporter {
    * @returns {string[]} Array of named export strings
    */
   getNamedExports() {
-    return this.exports.map(namedExport => `exports.${namedExport} = ${namedExport};`)
+    return this.exports.map(namedExport => `exports.${namedExport} = ${namedExport};`);
   }
 
   /**

--- a/src/global-exporter.js
+++ b/src/global-exporter.js
@@ -1,24 +1,18 @@
-import assign from 'lodash.assign';
+export default class GlobalExporter {
+  /**
+   * Generates the export statements for source code.
+   * @param {string} defaultExport Name of the global variable to export as default
+   * @param {string[]} [exports=[]] Named exports
+   */
+  constructor(defaultExport, exports = []) {
+    if (!(defaultExport || exports.length)) {
+      throw new Error('Must provide either default or named exports, or both.');
+    }
 
-/**
- * Generates the export statements for source code.
- * @param {string} defaultExport Name of the global variable to export as default
- * @param {string[]} [exports=[]] Named exports
- */
-export default function GlobalExporter(defaultExport, exports = []) {
-  if (!(this instanceof GlobalExporter)) {
-    return new GlobalExporter(defaultExport, exports);
+    this.defaultExport = defaultExport;
+    this.exports = exports;
   }
 
-  if (!(defaultExport || exports.length)) {
-    throw new Error('Must provide either default or named exports, or both.');
-  }
-
-  this.defaultExport = defaultExport;
-  this.exports = exports;
-}
-
-assign(GlobalExporter.prototype, {
   /**
    * Returns export strings for all the named exports.
    * @returns {string[]} Array of named export strings
@@ -26,7 +20,7 @@ assign(GlobalExporter.prototype, {
    */
   _getNamedExports() {
     return this.exports.map(namedExport => `export ${namedExport}`);
-  },
+  }
 
   /**
    * Returns default export string.
@@ -37,7 +31,7 @@ assign(GlobalExporter.prototype, {
     if (this.defaultExport) {
       return `export default ${this.defaultExport}`;
     }
-  },
+  }
 
   /**
    * Gets array of all the export statements.
@@ -53,7 +47,7 @@ assign(GlobalExporter.prototype, {
     }
 
     return exports.join(';\n') + ';';
-  },
+  }
 
   /**
    * Processes a source code file by adding export statements to the end of it.
@@ -70,4 +64,4 @@ assign(GlobalExporter.prototype, {
 
     return `${sourceCode}\n${exports}`;
   }
-});
+}

--- a/src/global-exporter.js
+++ b/src/global-exporter.js
@@ -1,9 +1,9 @@
-export default class GlobalExporter {
-  /**
-   * Generates the export statements for source code.
-   * @param {string} defaultExport Name of the global variable to export as default
-   * @param {string[]} [exports=[]] Named exports
-   */
+/**
+ * Generates the export statements for source code.
+ * @param {string} defaultExport Name of the global variable to export as default
+ * @param {string[]} [exports=[]] Named exports
+ */
+export class BaseGlobalExporter {
   constructor(defaultExport, exports = []) {
     if (!(defaultExport || exports.length)) {
       throw new Error('Must provide either default or named exports, or both.');
@@ -16,21 +16,19 @@ export default class GlobalExporter {
   /**
    * Returns export strings for all the named exports.
    * @returns {string[]} Array of named export strings
-   * @private
+   * @abstract
    */
-  _getNamedExports() {
-    return this.exports.map(namedExport => `export ${namedExport}`);
+  getNamedExports() {
+    throw new Error('not implemented');
   }
 
   /**
    * Returns default export string.
    * @returns {string} Default export string
-   * @private
+   * @abstract
    */
-  _getDefaultExport() {
-    if (this.defaultExport) {
-      return `export default ${this.defaultExport}`;
-    }
+  getDefaultExport() {
+    throw new Error('not implemented');
   }
 
   /**
@@ -38,9 +36,9 @@ export default class GlobalExporter {
    * @returns {string[]} Gets array of all named exports
    * @private
    */
-  _getExports() {
-    const exports = this._getNamedExports(),
-          defaultExport = this._getDefaultExport();
+  getExports() {
+    const exports = this.getNamedExports(),
+          defaultExport = this.getDefaultExport();
 
     if (defaultExport) {
       exports.push(defaultExport);
@@ -55,7 +53,7 @@ export default class GlobalExporter {
    * @returns {string} Source code with the exports added
    */
   processSourceCode(sourceCode) {
-    const exports = this._getExports();
+    const exports = this.getExports();
 
     // Add a leading semi-colon iff the last non-whitespace character is not one.
     if (!/;\s*$/.test(sourceCode)) {
@@ -64,4 +62,69 @@ export default class GlobalExporter {
 
     return `${sourceCode}\n${exports}`;
   }
+}
+
+/**
+ * Generates ES6 export statements.
+ */
+export class Es6GlobalExporter extends BaseGlobalExporter {
+  /**
+   * Returns export strings for all the named exports.
+   * @returns {string[]} Array of named export strings
+   */
+  getNamedExports() {
+    return this.exports.map(namedExport => `export ${namedExport}`);
+  }
+
+  /**
+   * Returns default export string.
+   * @returns {string} Default export string
+   */
+  getDefaultExport() {
+    if (this.defaultExport) {
+      return `export default ${this.defaultExport}`;
+    }
+  }
+}
+
+/**
+ * Generates CommonJS export statements.
+ */
+export class CjsGlobalExporter extends BaseGlobalExporter {
+  /**
+   * Returns export strings for all the named exports.
+   * @returns {string[]} Array of named export strings
+   */
+  getNamedExports() {
+    return this.exports.map(namedExport => `exports.${namedExport} = ${namedExport};`)
+  }
+
+  /**
+   * Returns default export string.
+   * @returns {string} Default export string
+   */
+  getDefaultExport() {
+    if (this.defaultExport) {
+      return `
+        Object.defineProperty(exports, '__esModule', {
+          value: true;
+        });
+        exports['default'] = ${this.defaultExport};
+      `;
+    }
+  }
+}
+
+/**
+ * Factory function that returns a specific exporter type based on the
+ * requested module type.
+ * @param {string} moduleType The module type for which to get an Exporter instance
+ * @returns {BaseGlobalExporter} Exporter instance
+ */
+export function getExporter(moduleType, ...args) {
+  let Exporter = Es6GlobalExporter;
+  if (moduleType === 'cjs') {
+    Exporter = CjsGlobalExporter;
+  }
+  return new Exporter(...args);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import { getExporter } from './global-exporter';
  * @param {object} [options={}] Configuration options for export writer
  * @param {string} [options.defaultExport] The name of the default export for the file
  * @param {string[]} [options.exports=[]] List of named exports
+ * @param {string} [options.moduleType=es2015] Type of module exports
  */
 export default function GlobalExportWriter(inputTree, fileName, options = {}) {
   if (!(this instanceof GlobalExportWriter)) {
@@ -23,7 +24,8 @@ export default function GlobalExportWriter(inputTree, fileName, options = {}) {
   }
 
   options = defaults(options, {
-    exports: []
+    exports: [],
+    moduleType: 'es2015'
   });
 
   if (Array.isArray(inputTree)) {
@@ -35,7 +37,7 @@ export default function GlobalExportWriter(inputTree, fileName, options = {}) {
   });
 
   this.fileName = fileName;
-  this.exporter = getExporter('es2015', options.defaultExport, options.exports);
+  this.exporter = getExporter(options.moduleType, options.defaultExport, options.exports);
 }
 
 util.inherits(GlobalExportWriter, BroccoliPlugin);

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import first from 'lodash.first';
 import defaults from 'lodash.defaults';
 import assign from 'lodash.assign';
 
-import GlobalExporter from './global-exporter';
+import { getExporter } from './global-exporter';
 
 /**
  * Broccoli plugin that adds ES6 export statements to files.
@@ -35,7 +35,7 @@ export default function GlobalExportWriter(inputTree, fileName, options = {}) {
   });
 
   this.fileName = fileName;
-  this.exporter = new GlobalExporter(options.defaultExport, options.exports);
+  this.exporter = getExporter('es2015', options.defaultExport, options.exports);
 }
 
 util.inherits(GlobalExportWriter, BroccoliPlugin);


### PR DESCRIPTION
Refactors the exporters into a generic base class with an ES6 exporter (default) and a CJS exporter. Fixes #13.
