### PR TITLE
Added .npmignore file. Fixes #33.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+/node_modules
+/coverage
+/specs


### PR DESCRIPTION
This RB adds a `.npmignore` file, in order to prevent `/dist` being ignored during `npm pack`. See #33 for more details.

I also:
- added `specs/` from the ignore list, since it's not required, and it makes sense to be excluded
- kept `src/` in the package. It's not required _per se_, but some people might be interested in getting the source code and transpile it themselves
